### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ Storage keys can be dynamically defined using dynamic parse syntax; this mimics 
 
 * **Expanded VP (Virtual Patch) ruleset**: Increase coverage of emerging threats.
 * **HTTP header/body response collections**: Use `header_filter_by_lua` and `body_filter_by_lua` to examine response headers and content. This could be used to build more extensive and complex chains.
-* **Multiple phase handling**: Ties in with response collections. The biggest challange will be keeping track of the `ctx` between multiple phases (bearing in mind that [ngx.ctx is expensive](https://www.cryptobells.com/openresty-performance-ngx-ctx-vs-ngx-shared-dict/)).
+* **Multiple phase handling**: Ties in with response collections. The biggest challenge will be keeping track of the `ctx` between multiple phases (bearing in mind that [ngx.ctx is expensive](https://www.cryptobells.com/openresty-performance-ngx-ctx-vs-ngx-shared-dict/)).
 * **Rule flow optimization**: Pre-calculating rule flow, as [suggested by @splitice](https://github.com/p0pr0ck5/FreeWAF/issues/39).
 * **Improve (debug) logging**: Log levels?
 * **Unit tests**: Testing function, collection, transform, chain, and rule behavior.


### PR DESCRIPTION
@p0pr0ck5, I've corrected a typographical error in the documentation of the [FreeWAF](https://github.com/p0pr0ck5/FreeWAF) project. Specifically, I've changed challange to challenge. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.