### PR TITLE
Add contextual details to log events

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ Defines the threshold size, in bytes, of the buffer to be used to hold event log
 
 Defines an interval, in seconds, at which the event log buffer will periodically flush. If no value is configured, the buffer will not flush periodically, and will only flush when the `event_log_buffer_size` threshold is reached. Configure this option for very low traffic sites that may not receive any event log data in a long period of time, to prevent stale data from sitting in the buffer.
 
+*Example*:
 
 ```lua
 	location / {
@@ -372,6 +373,53 @@ Defines an interval, in seconds, at which the event log buffer will periodically
 			fw:set_option("event_log_periodic_flush", 30)
 		';
 	}
+```
+
+###event_log_save_post_data
+
+*Default*: false
+
+Defines if the POST data should be saved with the event.
+
+*Example*:
+
+```lua
+	location / {
+		access_by_lua '
+			-- save the POST data with the alerts
+			fw:set_option("event_log_save_post_data", true)
+		';
+	}
+```
+
+###event_log_ngx_vars
+
+*Default*: empty
+
+Defines what extra variables from ```ngx.var``` are put to the log event. This is a generic way to extend the alert with extra context. The variable name will be the key of the value in the resulting json object. If the variable is not present as an nginx variable, no item is added to the event.
+
+*Example*:
+
+```lua
+	location / {
+		access_by_lua '
+			-- save the POST data with the alerts
+			fw:set_option("event_log_ngx_vars", "remote_user")
+			fw:set_option("event_log_ngx_vars", "request_id")
+		';
+	}
+```
+
+The resulting event has these extra items:
+
+```json
+{
+	...
+	"remote_user":"username",
+	"rule":{"id":21011},
+	"request_id": "373bcce584e3c18a"
+	...
+}
 ```
 
 ###storage_zone

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ Defines what extra variables from ```ngx.var``` are put to the log event. This i
 	location / {
 		access_by_lua '
 			-- save the POST data with the alerts
-			fw:set_option("event_log_ngx_vars", "remote_user")
+			fw:set_option("event_log_ngx_vars", "host")
 			fw:set_option("event_log_ngx_vars", "request_id")
 		';
 	}
@@ -415,8 +415,8 @@ The resulting event has these extra items:
 ```json
 {
 	...
-	"remote_user":"username",
-	"rule":{"id":21011},
+	"host": "example.com",
+	"rule": {"id": 21011},
 	"request_id": "373bcce584e3c18a"
 	...
 }

--- a/fw.lua
+++ b/fw.lua
@@ -278,7 +278,6 @@ local function _log_event(self, collections, rule, match)
 	local t = {
 		timestamp = ngx.time(),
 		client = collections["IP"],
-		host = ngx.var.host,
 		method = collections["METHOD"],
 		uri = collections["URI"],
 		args = collections["URI_ARGS"],


### PR DESCRIPTION
This PR introduce extra elements in the alert structure (HTTP method, URI arguments, HTTP headers and the score). It adds two extra config parameters: one to include the POST data in to the log, and an other which allows saving other nginx variables.