### PR TITLE
Patch for allowed_content_types set_option directive

### DIFF
--- a/fw.lua
+++ b/fw.lua
@@ -890,6 +890,10 @@ function _M.set_option(self, option, value)
 				_fatal_fail("Attempted to set FreeWAF storage zone as " .. tostring(value) .. ", but that lua_shared_dict does not exist")
 			end
 			self._storage_zone = value
+		end,
+		allowed_content_types = function(value)
+			local t = self._allowed_content_types
+			self._allowed_content_types[#t + 1] = value
 		end
 	}
 


### PR DESCRIPTION
Using fw:set_option("allowed_content_types", { "text/html", "text/json", "application/json" } ) in the openresty config was ineffective as _allowed_content_types was not populated on initialisation.

This resulted in errors trying to find needle ("application/json") in haystack ("") because haystack was a string, not a table. Openresty replied with a 500 response code and the following in error.log:

"2015/12/29 13:06:39 [error] 1838#0: *7 lua entry thread aborted: runtime error: /opt/openresty/lualib/FreeWAF/fw.lua:26: Cannot search for a needle when haystack is type string
stack traceback:
coroutine 0:
[C]: in function 'error'
/opt/openresty/lualib/FreeWAF/fw.lua:26: in function '_fatal_fail'
/opt/openresty/lualib/FreeWAF/fw.lua:136: in function '_table_has_value'
/opt/openresty/lualib/FreeWAF/fw.lua:564: in function '_parse_request_body'
/opt/openresty/lualib/FreeWAF/fw.lua:782: in function 'exec'
access_by_lua(matrix-common:93):19: in function , client: ...."

This pull request populates _allowed_content_types during initialisation and the allowed_content_types set_option now works as expected.

Pull request against master as (I think) requested.