### PR TITLE
Bugfixes in logging unit tests

### DIFF
--- a/t/log/01_logging.t
+++ b/t/log/01_logging.t
@@ -80,7 +80,7 @@ We have logged a string!
 GET /t
 --- reponse_body
 --- error_log eval
-qr/[warn].*We have logged a string!/
+qr/\[warn\].*We have logged a string!/
 --- no_error_log
 [error]
 
@@ -95,7 +95,7 @@ qr/[warn].*We have logged a string!/
 		access_by_lua '
 			local fw = FreeWAF:new()
 			fw:set_option("debug", true)
-			fw:set_option("debug_log_level", ngx.WARN)
+			fw:set_option("debug_log_level", ngx.DEBUG)
 			logger.log(fw, "We have logged a string!")
 		';
 
@@ -105,7 +105,7 @@ qr/[warn].*We have logged a string!/
 GET /t
 --- reponse_body
 --- error_log eval
-qr/[warn].*We have logged a string!/
+qr/\[debug\].*We have logged a string!/
 --- no_error_log
 [error]
 

--- a/t/log/02_fatal_fail.t
+++ b/t/log/02_fatal_fail.t
@@ -23,7 +23,7 @@ __DATA__
 GET /t
 --- error_code: 500
 --- error_log eval
-["in function 'fatal_fail'", qr/[error].*We have encountered a fatal failure!/]
+["in function 'fatal_fail'", qr/\[error\].*We have encountered a fatal failure!/]
 
 === TEST 2: Handle a fatal failure with warn error log level
 --- http_config
@@ -42,5 +42,5 @@ warn
 GET /t
 --- error_code: 500
 --- error_log eval
-["in function 'fatal_fail'", qr/[error].*We have encountered a fatal failure!/]
+["in function 'fatal_fail'", qr/\[error\].*We have encountered a fatal failure!/]
 


### PR DESCRIPTION
Log level regexes were not properly character classed, and a duplicate
test is now two separate tests.