### PR TITLE
Add contextual details to log events

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,6 @@ When set to true, the log entries contain the request arguments under the `uri_a
 ```lua
 	location / {
 		access_by_lua '
-			-- save the POST data with the alerts
 			fw:set_option("event_log_request_arguments", true)
 		';
 	}
@@ -515,7 +514,6 @@ The headers of the HTTP request is copied to the log event, under the `request_h
 ```lua
 	location / {
 		access_by_lua '
-			-- save the POST data with the alerts
 			fw:set_option("event_log_request_headers", true)
 		';
 	}

--- a/README.md
+++ b/README.md
@@ -459,6 +459,79 @@ Defines the MIME types with which FreeWAF will process the response body. This v
 
 Multiple MIME types can be added by passing a table of types to `set_option`.
 
+###event_log_ngx_vars
+
+*Default*: empty
+
+Defines what extra variables from `ngx.var` are put to the log event. This is a generic way to extend the alert with extra context. The variable name will be the key of the entry under an `ngx` key in the log entry. If the variable is not present as an nginx variable, no item is added to the event.
+
+*Example*:
+
+```lua
+	location / {
+		access_by_lua '
+			fw:set_option("event_log_ngx_vars", "host")
+			fw:set_option("event_log_ngx_vars", "request_id")
+		';
+	}
+```
+
+The resulting event has these extra items:
+
+```json
+{
+	"ngx": {
+		"host": "example.com",
+		"request_id": "373bcce584e3c18a"
+	}
+}
+```
+
+###event_log_request_arguments
+
+*Default*: false
+
+When set to true, the log entries contain the request arguments under the `uri_args` key.
+
+*Example*:
+
+```lua
+	location / {
+		access_by_lua '
+			-- save the POST data with the alerts
+			fw:set_option("event_log_request_arguments", true)
+		';
+	}
+```
+
+###event_log_request_headers
+
+*Default*: false
+
+The headers of the HTTP request is copied to the log event, under the `request_headers` key. 
+
+*Example*:
+
+```lua
+	location / {
+		access_by_lua '
+			-- save the POST data with the alerts
+			fw:set_option("event_log_request_headers", true)
+		';
+	}
+```
+
+The resulting event has these extra items:
+
+```json
+{
+	"request_headers": {
+		"accept": "*/*",
+		"user-agent": "curl/7.22.0 (x86_64-pc-linux-gnu) libcurl/7.22.0 OpenSSL/1.0.1 zlib/1.2.3.4 libidn/1.23 librtmp/2.3"
+	}
+}
+```
+
 ###storage_zone
 
 *Default*: none

--- a/lib/lookup.lua
+++ b/lib/lookup.lua
@@ -286,6 +286,10 @@ _M.set_option = {
 	res_body_mime_types = function(FW, value)
 		local t = FW._res_body_mime_types
 		FW._res_body_mime_types[#t + 1] = value
+	end,
+	event_log_ngx_vars = function(FW, value)
+		local t = FW._event_log_ngx_vars
+		FW._event_log_ngx_vars[#t + 1] = value
 	end
 }
 

--- a/t/acceptance/fw/02_logging.t
+++ b/t/acceptance/fw/02_logging.t
@@ -1,0 +1,64 @@
+use Test::Nginx::Socket::Lua;
+
+repeat_each(3);
+plan tests => repeat_each() * 3 * blocks();
+
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: Logs ngx.var
+--- http_config
+	init_by_lua '
+		local FreeWAF = require "fw"
+		FreeWAF.init()
+	';
+--- config
+	location /t {
+		access_by_lua '
+			local FreeWAF = require "fw"
+			local fw      = FreeWAF:new()
+
+			fw:set_option("debug", true)
+			fw:set_option("mode", "ACTIVE")
+			fw:set_option("event_log_ngx_vars", "args")
+			fw:exec()
+		';
+
+		content_by_lua 'ngx.exit(ngx.HTTP_OK)';
+	}
+--- request
+GET /t?foo=alert(1)
+--- error_code: 403
+--- error_log
+"ngx":{
+"args":"foo=alert(1)"
+
+=== TEST 2: Logs request arguments
+--- http_config
+	init_by_lua '
+		local FreeWAF = require "fw"
+		FreeWAF.init()
+	';
+--- config
+	location /t {
+		access_by_lua '
+			local FreeWAF = require "fw"
+			local fw      = FreeWAF:new()
+
+			fw:set_option("debug", true)
+			fw:set_option("mode", "ACTIVE")
+			fw:set_option("event_log_request_arguments", true)
+			fw:exec()
+		';
+
+		content_by_lua 'ngx.exit(ngx.HTTP_OK)';
+	}
+--- request
+GET /t?foo=alert(1)
+--- error_code: 403
+--- error_log
+"uri_args":{"foo":"alert(1)"}
+--- no_error_log
+[error]

--- a/t/acceptance/http/01_protocol_violations.t
+++ b/t/acceptance/http/01_protocol_violations.t
@@ -38,7 +38,7 @@ Content-Type: application/x-www-form-urlencoded
 --- error_code: 200
 --- error_log
 http header: "Content-Length: 7"
-"rule":{"id":20002}}
+"id":20002
 
 === TEST 2: POST request with a body
 --- http_config
@@ -71,7 +71,7 @@ Content-Type: application/x-www-form-urlencoded
 --- error_log
 http header: "Content-Length: 7"
 --- no_error_log
-"rule":{"id":20002}}
+"id":20002
 
 === TEST 3: POST request does not have a Content-Length header
 --- http_config
@@ -103,7 +103,7 @@ Accept: */*\r
 --- no_error_log
 http header: "Content-Length: 7"
 --- error_log
-"rule":{"id":20004}}
+"id":20004
 
 === TEST 4: POST request with a body
 --- http_config
@@ -136,7 +136,7 @@ Content-Type: application/x-www-form-urlencoded
 --- error_log
 http header: "Content-Length: 7"
 --- no_error_log
-"rule":{"id":20004}}
+"id":20004
 
 === TEST 5: Content-Encoding header contains 'identity'
 --- http_config
@@ -166,7 +166,7 @@ Accept: */*
 Content-Encoding: Identity
 --- error_code: 200
 --- error_log
-"rule":{"id":20005}}
+"id":20005
 --- no_error_log
 [error]
 
@@ -198,7 +198,7 @@ Pragma: no-cache
 Accept: */*
 --- error_code: 200
 --- error_log
-"rule":{"id":20011}}
+"id":20011
 --- no_error_log
 [error]
 
@@ -230,7 +230,7 @@ Accept: */*
 Range: bytes=0-9999
 --- error_code: 200
 --- error_log
-"rule":{"id":20012}}
+"id":20012
 --- no_error_log
 [error]
 
@@ -263,7 +263,7 @@ Range: bytes=0-1,2-3,4-5,6-7,8-9,10-
 User-Agent: test
 --- error_code: 200
 --- error_log
-"rule":{"id":20013}}
+"id":20013
 --- no_error_log
 [error]
 
@@ -295,7 +295,7 @@ Accept: */*
 Request-Range: bytes=0-1,2-3,4-5,6-7,8-9,10-
 --- error_code: 200
 --- error_log
-"rule":{"id":20014}}
+"id":20014
 --- no_error_log
 [error]
 
@@ -327,7 +327,7 @@ Accept: */*
 Connection: keep-alive, close
 --- error_code: 200
 --- error_log
-"rule":{"id":20015}}
+"id":20015
 --- no_error_log
 [error]
 

--- a/t/acceptance/http/02_protocol_anomalies.t
+++ b/t/acceptance/http/02_protocol_anomalies.t
@@ -36,7 +36,7 @@ User-Agent: Hostless
 \r\n\n"
 --- error_code: 200
 --- error_log
-"rule":{"id":21001}}
+"id":21001
 --- no_error_log
 [error]
 
@@ -67,7 +67,7 @@ GET /t
 User-Agent: Acceptless
 --- error_code: 200
 --- error_log
-"rule":{"id":21003}}
+"id":21003
 --- no_error_log
 [error]
 
@@ -98,7 +98,7 @@ GET /t
 Accept:
 --- error_code: 200
 --- error_log
-"rule":{"id":21005}}
+"id":21005
 --- no_error_log
 [error]
 
@@ -127,7 +127,7 @@ Accept:
 GET /t
 --- error_code: 200
 --- error_log
-"rule":{"id":21006}}
+"id":21006
 --- no_error_log
 [error]
 
@@ -158,7 +158,7 @@ GET /t
 User-Agent:
 --- error_code: 200
 --- error_log
-"rule":{"id":21007}}
+"id":21007
 --- no_error_log
 [error]
 
@@ -191,7 +191,7 @@ Accept: */*
 User-Agent: Typeless
 --- error_code: 200
 --- error_log
-"rule":{"id":21009}}
+"id":21009
 --- no_error_log
 [error]
 
@@ -223,7 +223,7 @@ Accept: */*
 \r\n\n"
 --- error_code: 200
 --- error_log
-"rule":{"id":21010}}
+"id":21010
 --- no_error_log
 [error]
 

--- a/t/acceptance/user_agent/01_known_baddies.t
+++ b/t/acceptance/user_agent/01_known_baddies.t
@@ -35,8 +35,8 @@ GET /t
 Accept: */*
 --- error_code: 200
 --- no_error_log
-"rule":{"id":35001}}
-"rule":{"id":35003}}
+"id":35001
+"id":35003
 
 === TEST 2: Valid User-Agent sent
 --- http_config
@@ -66,8 +66,8 @@ User-Agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) 
 Accept: */*
 --- error_code: 200
 --- no_error_log
-"rule":{"id":35001}}
-"rule":{"id":35003}}
+"id":35001
+"id":35003
 
 === TEST 3: Known automated scanner
 --- http_config
@@ -97,9 +97,9 @@ User-Agent: WebInspect
 Accept: */*
 --- error_code: 200
 --- error_log
-"rule":{"id":35001}}
+"id":35001
 --- no_error_log
-"rule":{"id":35003}}
+"id":35003
 
 === TEST 4: Known malicious User-Agent
 --- http_config
@@ -129,7 +129,7 @@ User-Agent: Internet-Exprorer
 Accept: */*
 --- error_code: 200
 --- error_log
-"rule":{"id":35003}}
+"id":35003
 --- no_error_log
-"rule":{"id":35001}}
+"id":35001
 

--- a/t/acceptance/xss/01_reflected.t
+++ b/t/acceptance/xss/01_reflected.t
@@ -53,12 +53,12 @@ GET /t?foo=bar
 --- response_body
 You've entered the following: 'bar'
 --- no_error_log
-"rule":{"id":42043}}
-"rule":{"id":42059}}
-"rule":{"id":42069}}
-"rule":{"id":42076}}
-"rule":{"id":42083}}
-"rule":{"id":99001}}
+"id":42043
+"id":42059
+"id":42069
+"id":42076
+"id":42083
+"id":99001
 
 === TEST 3: Benign request is not caught in ACTIVE mode
 --- http_config
@@ -89,12 +89,12 @@ GET /t?foo=bar
 --- response_body
 You've entered the following: 'bar'
 --- no_error_log
-"rule":{"id":42043}}
-"rule":{"id":42059}}
-"rule":{"id":42069}}
-"rule":{"id":42076}}
-"rule":{"id":42083}}
-"rule":{"id":99001}}
+"id":42043
+"id":42059
+"id":42069
+"id":42076
+"id":42083
+"id":99001
 
 === TEST 4: Malicious request exploits reflected XSS vulnerability
 --- config
@@ -141,12 +141,12 @@ GET /t?foo=<script>alert(1)</script>
 --- response_body
 You've entered the following: '<script>alert(1)</script>'
 --- error_log
-"rule":{"id":42043}}
-"rule":{"id":42059}}
-"rule":{"id":42069}}
-"rule":{"id":42076}}
-"rule":{"id":42083}}
-"rule":{"id":99001}}
+"id":42043
+"id":42059
+"id":42069
+"id":42076
+"id":42083
+"id":99001
 --- no_error_log
 [error]
 
@@ -179,12 +179,12 @@ GET /t?foo=<script>alert(1)</script>
 --- response_body_unlike
 You've entered the following: '<script>alert\(1\)</script>'
 --- error_log
-"rule":{"id":42043}}
-"rule":{"id":42059}}
-"rule":{"id":42069}}
-"rule":{"id":42076}}
-"rule":{"id":42083}}
-"rule":{"id":99001}}
+"id":42043
+"id":42059
+"id":42069
+"id":42076
+"id":42083
+"id":99001
 --- no_error_log
 [error]
 

--- a/t/acceptance/xss/02_stored.t
+++ b/t/acceptance/xss/02_stored.t
@@ -87,7 +87,7 @@ __DATA__
 --- response_body eval
 ["Set key 'foo'!\n", "shm:foo is set as: 'bar'\n"]
 --- no_error_log
-"rule":{"id":99001}}
+"id":99001
 
 === TEST 3: Benign request is not caught in ACTIVE mode
 --- http_config
@@ -140,7 +140,7 @@ __DATA__
 --- response_body eval
 ["Set key 'foo'!\n", "shm:foo is set as: 'bar'\n"]
 --- no_error_log
-"rule":{"id":99001}}
+"id":99001
 
 === TEST 4: Malicious request exploits stored XSS vulnerability
 --- http_config
@@ -171,7 +171,7 @@ __DATA__
 --- response_body eval
 ["Set key 'foo'!\n", "shm:foo is set as: '<script>alert(1)</script>'\n"]
 --- no_error_log
-"rule":{"id":99001}}
+"id":99001
 
 === TEST 5: Malicious request is logged in SIMULATE mode
 --- http_config
@@ -222,7 +222,7 @@ __DATA__
 --- response_body eval
 ["Set key 'foo'!\n", "shm:foo is set as: '<script>alert(1)</script>'\n"]
 --- error_log
-"rule":{"id":99001}}
+"id":99001
 
 === TEST 6: Malicious request is blocked in ACTIVE mode
 --- http_config
@@ -277,5 +277,5 @@ __DATA__
 --- response_body_unlike
 ["Set key 'foo'!", <script>alert\(1\)</script>]
 --- error_log
-"rule":{"id":99001}}
+"id":99001
 


### PR DESCRIPTION
This PR changes the structure of logging. Each request (which generates an alert) is creating a single log entry (as opposed to one log entry per alert). This removes the redundancy in the contextual information (ie. client ip and uri path).

The following parameters of the request are added to the log entry (non-configurable):
 * ```method```: HTTP method
 * ```score```: the total score of the request

The following parameters of the request are new and configurable (disabled by default):
 * request headers; the format allows efficient mapping setup in document-stores.
 * nginx internal variables (anything from ```ngx.var```)
 * GET parameters