### PR TITLE
Fix typo in version

### DIFF
--- a/lib/resty/waf.lua
+++ b/lib/resty/waf.lua
@@ -28,7 +28,7 @@ end
 
 local mt = { __index = _M }
 
-_M.version = base.lua
+_M.version = base.version
 
 -- default list of rulesets
 local _global_rulesets = {


### PR DESCRIPTION
Seems to be broken since https://github.com/p0pr0ck5/lua-resty-waf/commit/233eb3bf395689d11396fcc33009e9b1592bde8e#diff-afa50e251ed9d81830af215272dc102aR25