### PR TITLE
Luarocks dependencies moved to .rockspec file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ OPM_LIBS   = hamishforbes/lua-resty-iputils p0pr0ck5/lua-resty-cookie \
 MAKE_LIBS  = $(C_LIBS) decode
 SO_LIBS    = libac.so libinjection.so libhtmlentities.so libdecode.so
 RULES      = rules
-ROCK_DEPS  = "lrexlib-pcre 2.7.2-1" busted luafilesystem
 
 LOCAL_LIB_DIR = lib/resty
 
@@ -55,11 +54,6 @@ clean-libs:
 
 clean-opm-libs:
 	$(OPM) --install-dir=$(OPM_LIB_DIR) remove $(OPM_LIBS)
-
-clean-rocks:
-	for ROCK in $(ROCK_DEPS); do \
-		$(LUAROCKS) remove $$ROCK; \
-	done
 
 clean-test:
 	rm -rf t/servroot*
@@ -127,15 +121,10 @@ test-fast: all
 install-check:
 	stat lib/*.so > /dev/null
 
-install-deps: install-opm-libs install-rocks
+install-deps: install-opm-libs
 
 install-opm-libs:
 	$(OPM) --install-dir=$(OPM_LIB_DIR) get $(OPM_LIBS)
-
-install-rocks:
-	for ROCK in $(ROCK_DEPS); do \
-		$(LUAROCKS) install $$ROCK; \
-	done
 
 install-link: install-check
 	$(INSTALL_SOFT) $(PWD)/lib/resty/* $(LUA_LIB_DIR)/resty/

--- a/lua-resty-waf-0.11.1-1.rockspec
+++ b/lua-resty-waf-0.11.1-1.rockspec
@@ -12,8 +12,11 @@ description = {
 dependencies = {
    "lua >= 5.1",
    "luarocks-fetch-gitrec",
+   "lrexlib-pcre",
+   "busted",
+   "luafilesystem",
 }
 build = {
    type = "make",
-   install_target = "install-hard",
+   install_target = "install",
 }


### PR DESCRIPTION
Trying to create consistent setup in the CentOS 6 environment and found that if I install the lua-resty-waf with the provided .rockspec - packages that it depends on get installed, but not added to the "luarocks list":

Here the output after the installation:

```
# luarocks  list
Installed rocks:
----------------
lua-resty-auto-ssl
   0.12.0-1 (installed) - /usr/local/openresty/luajit/lib/luarocks/rocks

lua-resty-http
   0.13-0 (installed) - /usr/local/openresty/luajit/lib/luarocks/rocks

lua-resty-waf
   0.11.1-2 (installed) - /usr/local/openresty/luajit/lib/luarocks/rocks

luarocks-fetch-gitrec
   0.2-1 (installed) - /usr/local/openresty/luajit/lib/luarocks/rocks 
```

But of I install dependencies first with `luarocks install busted` - everything looks good.

Decided to try to move the luarocks dependencies installation from Makefile back to .rockspec and everything looks smoother now and shows consistent list of libraries:

```
# luarocks list

Installed rocks:
----------------

busted
   2.0.rc13-0 (installed) - /usr/local/openresty/luajit/lib/luarocks/rocks

dkjson
   2.5-2 (installed) - /usr/local/openresty/luajit/lib/luarocks/rocks

lrexlib-pcre
   2.9.0-1 (installed) - /usr/local/openresty/luajit/lib/luarocks/rocks

lua-resty-auto-ssl
   0.12.0-1 (installed) - /usr/local/openresty/luajit/lib/luarocks/rocks

lua-resty-http
   0.13-0 (installed) - /usr/local/openresty/luajit/lib/luarocks/rocks

lua-resty-waf
   0.11.1-2 (installed) - /usr/local/openresty/luajit/lib/luarocks/rocks

lua-term
   0.7-1 (installed) - /usr/local/openresty/luajit/lib/luarocks/rocks

lua_cliargs
   3.0-1 (installed) - /usr/local/openresty/luajit/lib/luarocks/rocks

luafilesystem
   1.7.0-2 (installed) - /usr/local/openresty/luajit/lib/luarocks/rocks

luarocks-fetch-gitrec
   0.2-1 (installed) - /usr/local/openresty/luajit/lib/luarocks/rocks

luassert
   1.7.11-0 (installed) - /usr/local/openresty/luajit/lib/luarocks/rocks

luasystem
   0.2.1-0 (installed) - /usr/local/openresty/luajit/lib/luarocks/rocks

mediator_lua
   1.1.2-0 (installed) - /usr/local/openresty/luajit/lib/luarocks/rocks

penlight
   1.5.4-1 (installed) - /usr/local/openresty/luajit/lib/luarocks/rocks

say
   1.3-1 (installed) - /usr/local/openresty/luajit/lib/luarocks/rocks
```

Are there reasons why this can't be back-ported to your master tree?

And package doesn't build on CentOS 6 system because of the outdated GCC (4.4.7) - had to remove the `-flto` flag (https://github.com/kariedo/lua-resty-htmlentities/commit/4dbb9bf90ef67e6aa243c6e182e1d1aed1e788e9), but that's different story.