### PR TITLE
Add the possibility of applying sieves to a whole ruleset at a time

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ lua-resty-waf - High-performance WAF built on the OpenResty stack
 	* [lua-resty-waf:set_option()](#lua-resty-wafset_option)
 	* [lua-resty-waf:set_var()](#lua-resty-wafset_var)
 	* [lua-resty-waf:sieve_rule()](#lua-resty-wafsieve_rule)
+	* [lua-resty-waf:sieve_ruleset()](#lua-resty-wafsieve_ruleset)
 	* [lua-resty-waf:exec()](#lua-resty-wafexec)
 	* [lua-resty-waf:write_log_events()](#lua-resty-wafwrite_log_events)
 * [Options](#options)
@@ -349,6 +350,32 @@ location / {
 ```
 
 See the [rule sieves](https://github.com/p0pr0ck5/lua-resty-waf/wiki/Rule-Sieves) wiki page for details and advanced usage examples.
+
+### lua-resty-waf:sieve_ruleset()
+
+Define a collection exclusion for a given ruleset.
+
+*Example*:
+
+```lua
+location / {
+    access_by_lua_block {
+        local lua_resty_waf = require "resty.waf"
+
+        local waf = lua_resty_waf:new()
+
+        local sieves = {
+            {
+                type   = "ARGS",
+                elts   = "foo",
+                action = "ignore",
+            }
+        }
+
+        waf:sieve_ruleset("42000_xss", sieves)
+    }
+}
+```
 
 ### lua-resty-waf:exec()
 

--- a/lib/resty/waf.lua
+++ b/lib/resty/waf.lua
@@ -739,7 +739,7 @@ function _M.sieve_rule(self, id, sieves)
 			if self.target_update_map[id] then break end
 
 			for i, rule in ipairs(rules) do
-				if rule.id == id then
+				if rule.id == tonumber(id) then
 					orig_rule = rule
 					self.target_update_map[id] = util.table_copy(rule.vars)
 					break

--- a/lib/resty/waf.lua
+++ b/lib/resty/waf.lua
@@ -788,6 +788,65 @@ function _M.sieve_rule(self, id, sieves)
 	end
 end
 
+-- add extra sieve elements to a rule on a per-instance basis / apply to a whole ruleset at a time
+-- ruleset_name example: "42000_xss"
+function _M.sieve_ruleset(self, ruleset_name, sieves)
+	-- pointer to a rule
+	local target_update_map_opts_transform = {}
+
+	for r, ruleset in pairs(_ruleset_defs) do
+		if r == ruleset_name then
+			for phase, rules in pairs(ruleset) do
+				for i, rule in ipairs(rules) do
+					self.target_update_map[rule.id] = util.table_copy(rule.vars)
+					target_update_map_opts_transform[rule.id] = rule.opts.transform
+				end
+			end
+		end
+	end
+
+	for _, sieve in ipairs(sieves) do
+		local found
+		local arg = ""
+
+		if translate.valid_vars[sieve.type] then
+			arg = translate.valid_vars[sieve.type].type
+		end
+
+		-- search for the rule here
+		for rule_id, rule in pairs(self.target_update_map) do
+			for i = 1, #rule do
+				-- found it, append the sieves (ignore for now)
+				if arg == rule[i].type then
+					local elts = type(sieve.elts) == "table" and sieve.elts
+						or { sieve.elts }
+
+					if not rule[i].ignore then
+						rule[i].ignore = tab_new(#elts, 0)
+					end
+
+					for j = 1, #elts do
+						rule[i].ignore[j] = { sieve.action, elts[j] }
+					end
+
+					-- set/update the var's collection key
+					rule[1].collection_key =
+						calc.build_collection_key(
+							rule[i],
+							target_update_map_opts_transform[rule_id])
+
+					found = true
+					break
+				end
+			end
+
+			if not found then
+				ngx.log(ngx.WARN, arg .. " undefined in rule " .. rule_id)
+			end
+		end
+	end
+end
+
 -- push log data regarding matching rule(s) to the configured target
 -- in the case of socket or file logging, this data will be buffered
 function _M.write_log_events(self, has_ctx, ctx)


### PR DESCRIPTION
The aim of the PR is to add a feature to apply sieves to a whole ruleset at a time (not juste one rule at a time).
It also comes with a fix for the `sieve_rule` function which did not work if the rule ID was a string (e.g. `"12345"` like the documentation suggests).